### PR TITLE
fix: migrations failing

### DIFF
--- a/database/migrations/2025_04_21_154602_create_port_numbers_table.php
+++ b/database/migrations/2025_04_21_154602_create_port_numbers_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('port_numbers', function (Blueprint $table) {
-            $table->uuid('id')->primary();
+            $table->id();
             $table->integer('port');
             $table->boolean('is_active');
             $table->foreignUuid('container_id')->references('id')->on('containers')->onDelete('cascade');

--- a/database/migrations/2025_04_30_073144_update_id_on_port_numbers_table.php
+++ b/database/migrations/2025_04_30_073144_update_id_on_port_numbers_table.php
@@ -10,7 +10,6 @@ return new class extends Migration
     {
         Schema::table('port_numbers', function (Blueprint $table) {
             if (config('database.default') === 'mysql') {
-                $table->dropPrimary();
                 $table->dropColumn('id');
 
                 $table->uuid('id')->primary();
@@ -22,7 +21,6 @@ return new class extends Migration
     {
         Schema::table('port_numbers', function (Blueprint $table) {
             if (config('database.default') === 'mysql') {
-                $table->dropPrimary();
                 $table->dropColumn('id');
 
                 $table->id()->change();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated database migrations for the port numbers table to change the primary key from a UUID to an auto-incrementing big integer.
  - Simplified migration steps for modifying the primary key column by removing unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->