### PR TITLE
fix: use query parameters instead of form-body

### DIFF
--- a/app/Actions/DeleteInstanceAction.php
+++ b/app/Actions/DeleteInstanceAction.php
@@ -18,10 +18,10 @@ class DeleteInstanceAction
      */
     public function execute(Request $request, Instance $instance): void
     {
-        $response = Http::proxmox()->delete('/vm/delete_vm', [
-            'node' => 'node1',
+        $response = Http::proxmox()->withQueryParameters([
+            'node' => $instance->node,
             'vmid' => $instance->vm_id,
-        ]);
+        ])->delete('/vm/delete_vm');
 
         if (! $response->successful()) {
             Log::error('Failed to delete instance: {instance}. Error message: {message}', [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of VM instance deletion by correctly sending parameters as query values, ensuring the correct node and VM ID are used during the deletion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->